### PR TITLE
Fix Travis CI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,32 +1,28 @@
 sudo: false
-dist: trusty
 language: php
 
 env:
   global:
   - DB=mysql
 
+services:
+  - mysql
+
 matrix:
   include:
-  - php: 5.3
-    dist: precise
-  - php: 5.4
-  - php: 5.5
   - php: 5.6
   - php: 7.0
   - php: 7.1
   - php: 7.2
+  - php: 7.3
   - php: nightly
   - php: hhvm
   fast_finish: true
   allow_failures:
   - php: nightly
-  - php: 7.2
   - php: hhvm
 
 before_script:
-  - which phpunit
-  - phpunit --version
   - mysql --version
   - git clone git://github.com/YOURLS/YOURLS.git
   - |
@@ -44,7 +40,9 @@ before_script:
   - mysql -e 'create database IF NOT EXISTS yourls_tests;'
   - cp yourls-tests-config-travis.php YOURLS/user/config.php
 
-script: phpunit --configuration ./phpunit-travis.xml.dist
+install: composer install
+
+script: vendor/bin/phpunit --configuration ./phpunit-travis.xml.dist
 
 notifications:
   email: false

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
     "require": {
-        "phpunit/phpunit": "4.*"
+        "phpunit/phpunit": "^5.7"
     }
 }

--- a/tests/http/api-check.php
+++ b/tests/http/api-check.php
@@ -11,7 +11,7 @@ class HTTP_AYO_Tests extends PHPUnit_Framework_TestCase {
     protected function tearDown() {
         yourls_remove_all_filters( 'is_admin' );
     }
-    
+
     /**
      * Check that version checking returns expected stuff and updates the relevant option
      *
@@ -21,11 +21,11 @@ class HTTP_AYO_Tests extends PHPUnit_Framework_TestCase {
         $before = yourls_get_option( 'core_version_checks' );
         $check = yourls_check_core_version();
         $after = yourls_get_option( 'core_version_checks' );
-        
+
         if( $check === false ) {
             $this->markTestSkipped( 'api.yourls.org unreachable or broken' );
         }
-        
+
         $this->assertNotSame( $before, $after );
         $this->assertTrue( isset( $check->latest ) );
         $this->assertTrue( isset( $check->zipurl ) );
@@ -40,7 +40,7 @@ class HTTP_AYO_Tests extends PHPUnit_Framework_TestCase {
         yourls_add_filter( 'is_admin', 'yourls_return_false' );
         $this->assertFalse( yourls_maybe_check_core_version() );
     }
-    
+
     /**
      * Generate an object to mock last attempt of checking against api.yourls.org
      */
@@ -50,7 +50,7 @@ class HTTP_AYO_Tests extends PHPUnit_Framework_TestCase {
         $checks->failed_attempts = $failed_attempts;
         $checks->last_attempt    = $last_attempt;
         $checks->version_checked = $version_checked;
-        
+
         return $checks;
     }
 
@@ -67,14 +67,14 @@ class HTTP_AYO_Tests extends PHPUnit_Framework_TestCase {
          * Then : we DO want to check
          */
         $name = 'Case 0';
-        $checks = null;
+        $checks = '';
         $expected = true;
         $return[] = array( $name, $checks, $expected );
-        
+
         // Now all possible cases : see https://gist.github.com/ozh/17ea830b2f688613927f
 
         /**
-         * Case 1 : previous check 
+         * Case 1 : previous check
          * - was SUCCESSFUL,
          * - was performed MORE than 24 hours ago,
          * - and version checked DID match current version
@@ -88,9 +88,9 @@ class HTTP_AYO_Tests extends PHPUnit_Framework_TestCase {
         );
         $expected = true;
         $return[] = array( $name, $checks, $expected );
-        
+
         /**
-         * Case 2 : previous check 
+         * Case 2 : previous check
          * - was SUCCESSFUL,
          * - was performed MORE than 24 hours ago,
          * - and version checked DID NOT match current version
@@ -104,9 +104,9 @@ class HTTP_AYO_Tests extends PHPUnit_Framework_TestCase {
         );
         $expected = true;
         $return[] = array( $name, $checks, $expected );
-        
+
         /**
-         * Case 3 : previous check 
+         * Case 3 : previous check
          * - was SUCCESSFUL,
          * - was performed LESS than 24 hours ago,
          * - and version checked DID match current version
@@ -120,9 +120,9 @@ class HTTP_AYO_Tests extends PHPUnit_Framework_TestCase {
         );
         $expected = false;
         $return[] = array( $name, $checks, $expected );
-        
+
         /**
-         * Case 4 : previous check 
+         * Case 4 : previous check
          * - was SUCCESSFUL,
          * - was performed LESS than 24 hours ago,
          * - and version checked DID NOT match current version
@@ -136,9 +136,9 @@ class HTTP_AYO_Tests extends PHPUnit_Framework_TestCase {
         );
         $expected = true;
         $return[] = array( $name, $checks, $expected );
-        
+
         /**
-         * Case 5 : previous check 
+         * Case 5 : previous check
          * - was NOT SUCCESSFUL,
          * - was performed MORE than 2 hours ago,
          * - and version checked DID match current version
@@ -152,9 +152,9 @@ class HTTP_AYO_Tests extends PHPUnit_Framework_TestCase {
         );
         $expected = true;
         $return[] = array( $name, $checks, $expected );
-        
+
         /**
-         * Case 6 : previous check 
+         * Case 6 : previous check
          * - was NOT SUCCESSFUL,
          * - was performed MORE than 2 hours ago,
          * - and version checked DID NOT match current version
@@ -168,9 +168,9 @@ class HTTP_AYO_Tests extends PHPUnit_Framework_TestCase {
         );
         $expected = true;
         $return[] = array( $name, $checks, $expected );
-        
+
         /**
-         * Case 7 : previous check 
+         * Case 7 : previous check
          * - was NOT SUCCESSFUL,
          * - was performed LESS than 2 hours ago,
          * - and version checked DID match current version
@@ -184,9 +184,9 @@ class HTTP_AYO_Tests extends PHPUnit_Framework_TestCase {
         );
         $expected = false;
         $return[] = array( $name, $checks, $expected );
-        
+
         /**
-         * Case 8 : previous check 
+         * Case 8 : previous check
          * - was NOT SUCCESSFUL,
          * - was performed LESS than 2 hours ago,
          * - and version checked DID NOT match current version
@@ -200,8 +200,8 @@ class HTTP_AYO_Tests extends PHPUnit_Framework_TestCase {
         );
         $expected = true;
         $return[] = array( $name, $checks, $expected );
-        
-        return $return;        
+
+        return $return;
     }
 
     /**
@@ -214,7 +214,7 @@ class HTTP_AYO_Tests extends PHPUnit_Framework_TestCase {
     public function test_api_check_in_various_scenario( $name, $checks, $expected ) {
         yourls_add_filter( 'is_admin', 'yourls_return_true' );
         yourls_update_option( 'core_version_checks', $checks );
-        
+
         $this->assertSame( $expected, yourls_maybe_check_core_version() );
     }
 

--- a/tests/plugins/actions.php
+++ b/tests/plugins/actions.php
@@ -22,13 +22,13 @@ class Plugin_Actions_Tests extends PHPUnit_Framework_TestCase {
         $this->assertFalse( yourls_has_action( $hook ) );
         yourls_add_action( $hook, rand_str() );
         $this->assertTrue( yourls_has_action( $hook ) );
-        
+
         // Specific function name to test with yourls_do_action
         $hook = rand_str();
         $this->assertFalse( yourls_has_action( $hook ) );
         yourls_add_action( $hook, 'change_one_global' );
         $this->assertTrue( yourls_has_action( $hook ) );
-        
+
         return $hook;
 	}
 
@@ -49,7 +49,7 @@ class Plugin_Actions_Tests extends PHPUnit_Framework_TestCase {
         yourls_remove_action( $hook, $action );
         $this->assertFalse( yourls_has_action( $hook ) );
     }
-    
+
     /**
      * Add several actions on the same hook
      *
@@ -57,7 +57,7 @@ class Plugin_Actions_Tests extends PHPUnit_Framework_TestCase {
      */
     public function test_add_several_actions_default_priority() {
         $hook = rand_str();
-        
+
         $times = mt_rand( 5, 15 );
         for ( $i = 1; $i <= $times; $i++ ) {
             yourls_add_action( $hook, rand_str() );
@@ -67,7 +67,7 @@ class Plugin_Actions_Tests extends PHPUnit_Framework_TestCase {
         global $yourls_filters;
         $this->assertSame( $times, count( $yourls_filters[ $hook ][10] ) );
     }
-    
+
     /**
      * Add several actions on the same hook with different priorities
      *
@@ -75,23 +75,23 @@ class Plugin_Actions_Tests extends PHPUnit_Framework_TestCase {
      */
     public function test_add_several_actions_random_priorities() {
         $hook = rand_str();
-        
+
         $times = mt_rand( 5, 15 );
         for ( $i = 1; $i <= $times; $i++ ) {
             yourls_add_action( $hook, rand_str(), mt_rand( 1, 10 ) );
         }
 
         $this->assertTrue( yourls_has_action( $hook ) );
-        
+
         global $yourls_filters;
         $total = 0;
         foreach( $yourls_filters[ $hook ] as $prio => $action ) {
             $total += count( $yourls_filters[ $hook ][ $prio ] );
         }
-        
+
         $this->assertSame( $times, $total );
     }
-    
+
     /**
      * Remove all actions on a hook
      *
@@ -99,17 +99,17 @@ class Plugin_Actions_Tests extends PHPUnit_Framework_TestCase {
      */
     public function test_remove_all_actions() {
         $hook = rand_str();
-        
+
         $times = mt_rand( 5, 15 );
         for ( $i = 1; $i <= $times; $i++ ) {
             yourls_add_action( $hook, rand_str() );
         }
-        
+
         $this->assertTrue( yourls_has_action( $hook ) );
         yourls_remove_all_actions( $hook );
         $this->assertFalse( yourls_has_action( $hook ) );
     }
-    
+
     /**
      * Remove all actions with random priorities on a hook
      *
@@ -117,17 +117,17 @@ class Plugin_Actions_Tests extends PHPUnit_Framework_TestCase {
      */
     public function test_remove_all_actions_random_prio() {
         $hook = rand_str();
-        
+
         $times = mt_rand( 5, 15 );
         for ( $i = 1; $i <= $times; $i++ ) {
             yourls_add_action( $hook, rand_str(), mt_rand( 1, 10 ) );
         }
-        
+
         $this->assertTrue( yourls_has_action( $hook ) );
         yourls_remove_all_actions( $hook );
         $this->assertFalse( yourls_has_action( $hook ) );
     }
-    
+
     /**
      * Remove all actions with specific priority
      *
@@ -136,7 +136,7 @@ class Plugin_Actions_Tests extends PHPUnit_Framework_TestCase {
     public function test_remove_only_actions_with_given_prio() {
         $hook = rand_str();
         $priorities = array();
-        
+
         $times = mt_rand( 10, 30 );
         for ( $i = 1; $i <= $times; $i++ ) {
             $prio = mt_rand( 1, 100 );
@@ -144,7 +144,7 @@ class Plugin_Actions_Tests extends PHPUnit_Framework_TestCase {
             yourls_add_action( $hook, rand_str(), $prio );
         }
         $this->assertTrue( yourls_has_action( $hook ) );
-        
+
         global $yourls_filters;
 
         // Pick a random number of randomly picked priorities (but not all of them)
@@ -157,14 +157,14 @@ class Plugin_Actions_Tests extends PHPUnit_Framework_TestCase {
             if( in_array( $prio, $random_priorities ) )
                 $removed += count( $yourls_filters[ $hook ][ $prio ] );
         }
-        
+
         // Remove the randomly picked priorities
         foreach( $random_priorities as $random_priority ) {
             yourls_remove_all_actions( $hook, $random_priority );
         }
-        
+
         $this->assertTrue( yourls_has_action( $hook ) );
-        
+
         // Count how many are left
         $remaining = 0;
         foreach( $yourls_filters[ $hook ] as $prio => $action ) {
@@ -172,7 +172,7 @@ class Plugin_Actions_Tests extends PHPUnit_Framework_TestCase {
         }
         $this->assertSame( $remaining, $times - $removed );
     }
-    
+
 	/**
 	 * Check 'doing' an action hooked with a simple function name
 	 *
@@ -184,13 +184,13 @@ class Plugin_Actions_Tests extends PHPUnit_Framework_TestCase {
         $var_value = rand_str();
         $GLOBALS['test_var']  = $var_name;
         $GLOBALS[ $var_name ] = $var_value;
-        
+
         $this->assertSame( $var_value, $GLOBALS[ $var_name ] );
         $this->assertSame( 0, yourls_did_action( $hook ) );
         yourls_do_action( $hook );
         $this->assertSame( 1, yourls_did_action( $hook ) );
         $this->assertNotSame( $var_value, $GLOBALS[ $var_name ] );
-        
+
         return $hook;
 	}
 
@@ -202,16 +202,16 @@ class Plugin_Actions_Tests extends PHPUnit_Framework_TestCase {
 	public function test_do_action_several_times_and_count() {
         $hook = rand_str();
         $this->assertSame( 0, yourls_did_action( $hook ) );
-        
+
         $times = mt_rand( 5, 15 );
         for ( $i = 1; $i <= $times; $i++ ) {
             yourls_do_action( $hook );
         }
-        
+
         $this->assertSame( $times, yourls_did_action( $hook ) );
 	}
 
-    
+
 	/**
 	 * Check adding an action with an anonymous function using create_function()
      *
@@ -222,12 +222,14 @@ class Plugin_Actions_Tests extends PHPUnit_Framework_TestCase {
 	public function test_add_action_create_function() {
         $hook = rand_str();
         $this->assertFalse( yourls_has_action( $hook ) );
-        yourls_add_action( $hook, create_function( '', '$var_name = $GLOBALS["test_var"]; $GLOBALS[ $var_name ] = rand_str();' ) );
+        yourls_add_action( $hook, function() {
+            $var_name = $GLOBALS["test_var"]; $GLOBALS[ $var_name ] = rand_str();
+        } );
         $this->assertTrue( yourls_has_action( $hook ) );
-               
+
         return $hook;
 	}
-    
+
 	/**
 	 * Check 'doing' an action hooked with an anonymous function using create_function()
 	 *
@@ -239,17 +241,17 @@ class Plugin_Actions_Tests extends PHPUnit_Framework_TestCase {
         $var_value = rand_str();
         $GLOBALS['test_var']  = $var_name;
         $GLOBALS[ $var_name ] = $var_value;
-        
+
         $this->assertSame( $var_value, $GLOBALS[ $var_name ] );
         $this->assertSame( 0, yourls_did_action( $hook ) );
         yourls_do_action( $hook );
         $this->assertSame( 1, yourls_did_action( $hook ) );
         $this->assertNotSame( $var_value, $GLOBALS[ $var_name ] );
-        
+
         return $hook;
 	}
-    
-    
+
+
 	/**
 	 * Check adding an action with function within class
      *
@@ -262,10 +264,10 @@ class Plugin_Actions_Tests extends PHPUnit_Framework_TestCase {
         $this->assertFalse( yourls_has_action( $hook ) );
         yourls_add_action( $hook, 'Change_One_Global::change_it' );
         $this->assertTrue( yourls_has_action( $hook ) );
-               
+
         return $hook;
 	}
-    
+
 	/**
 	 * Check 'doing' an action hooked with function within class
 	 *
@@ -277,16 +279,16 @@ class Plugin_Actions_Tests extends PHPUnit_Framework_TestCase {
         $var_value = rand_str();
         $GLOBALS['test_var']  = $var_name;
         $GLOBALS[ $var_name ] = $var_value;
-        
+
         $this->assertSame( $var_value, $GLOBALS[ $var_name ] );
         $this->assertSame( 0, yourls_did_action( $hook ) );
         yourls_do_action( $hook );
         $this->assertSame( 1, yourls_did_action( $hook ) );
         $this->assertNotSame( $var_value, $GLOBALS[ $var_name ] );
-        
+
         return $hook;
 	}
-    
+
 
 	/**
 	 * Check adding an action with function within class using an array
@@ -300,10 +302,10 @@ class Plugin_Actions_Tests extends PHPUnit_Framework_TestCase {
         $this->assertFalse( yourls_has_action( $hook ) );
         yourls_add_action( $hook, array( 'Change_One_Global', 'change_it' ) );
         $this->assertTrue( yourls_has_action( $hook ) );
-               
+
         return $hook;
 	}
-    
+
 	/**
 	 * Check 'doing' an action hooked with function within class
 	 *
@@ -315,16 +317,16 @@ class Plugin_Actions_Tests extends PHPUnit_Framework_TestCase {
         $var_value = rand_str();
         $GLOBALS['test_var']  = $var_name;
         $GLOBALS[ $var_name ] = $var_value;
-        
+
         $this->assertSame( $var_value, $GLOBALS[ $var_name ] );
         $this->assertSame( 0, yourls_did_action( $hook ) );
         yourls_do_action( $hook );
         $this->assertSame( 1, yourls_did_action( $hook ) );
         $this->assertNotSame( $var_value, $GLOBALS[ $var_name ] );
-        
+
         return $hook;
 	}
-    
+
 
 	/**
 	 * Check adding an action with function within class instance
@@ -338,10 +340,10 @@ class Plugin_Actions_Tests extends PHPUnit_Framework_TestCase {
         $this->assertFalse( yourls_has_action( $hook ) );
         yourls_add_action( $hook, array( $this, 'change_one_global' ) );
         $this->assertTrue( yourls_has_action( $hook ) );
-               
+
         return $hook;
 	}
-    
+
 	/**
 	 * Check 'doing' an action hooked with function within class instance
 	 *
@@ -353,16 +355,16 @@ class Plugin_Actions_Tests extends PHPUnit_Framework_TestCase {
         $var_value = rand_str();
         $GLOBALS['test_var']  = $var_name;
         $GLOBALS[ $var_name ] = $var_value;
-        
+
         $this->assertSame( $var_value, $GLOBALS[ $var_name ] );
         $this->assertSame( 0, yourls_did_action( $hook ) );
         yourls_do_action( $hook );
         $this->assertSame( 1, yourls_did_action( $hook ) );
         $this->assertNotSame( $var_value, $GLOBALS[ $var_name ] );
-        
+
         return $hook;
 	}
-    
+
 
 	/**
 	 * Check that hooking to 'Class::Method' or array( 'Class', 'Method') is the same
@@ -371,14 +373,14 @@ class Plugin_Actions_Tests extends PHPUnit_Framework_TestCase {
 	 */
 	public function test_add_action_class_and_array() {
         $hook = rand_str();
-        
+
         $this->assertFalse( yourls_has_action( $hook ) );
-        
+
         yourls_add_action( $hook, array( 'Class', 'Method' ) );
         $this->assertSame( 10, yourls_has_action( $hook, array( 'Class', 'Method' ) ) );
         $this->assertSame( 10, yourls_has_action( $hook, 'Class::Method' ) );
 	}
-    
+
 
 	/**
 	 * Check adding an action with anonymous function using closure
@@ -392,10 +394,10 @@ class Plugin_Actions_Tests extends PHPUnit_Framework_TestCase {
         $this->assertFalse( yourls_has_action( $hook ) );
         yourls_add_action( $hook, function() { $var_name = $GLOBALS['test_var']; $GLOBALS[ $var_name ] = rand_str(); } );
         $this->assertTrue( yourls_has_action( $hook ) );
-               
+
         return $hook;
 	}
-    
+
 	/**
 	 * Check 'doing' an action hooked with anonymous function using closure
 	 *
@@ -407,16 +409,16 @@ class Plugin_Actions_Tests extends PHPUnit_Framework_TestCase {
         $var_value = rand_str();
         $GLOBALS['test_var']  = $var_name;
         $GLOBALS[ $var_name ] = $var_value;
-        
+
         $this->assertSame( $var_value, $GLOBALS[ $var_name ] );
         $this->assertSame( 0, yourls_did_action( $hook ) );
         yourls_do_action( $hook );
         $this->assertSame( 1, yourls_did_action( $hook ) );
         $this->assertNotSame( $var_value, $GLOBALS[ $var_name ] );
-        
+
         return $hook;
 	}
-    
+
     /**
      * Check that applied function must exist
      *
@@ -429,7 +431,7 @@ class Plugin_Actions_Tests extends PHPUnit_Framework_TestCase {
         // this will trigger an error, converted to an exception by PHPUnit
         yourls_do_action( $hook );
     }
-    
+
     /**
      * Test yourls_do_action() with multiple params
      *
@@ -440,11 +442,11 @@ class Plugin_Actions_Tests extends PHPUnit_Framework_TestCase {
     public function test_do_action_no_params() {
         $hook = rand_str();
         yourls_add_action( $hook, array( $this, 'accept_multiple_params' ) );
-        
+
         $this->expectOutputString( "array (0 => '',)" );
         yourls_do_action( $hook );
     }
-    
+
     /**
      * Test yourls_do_action() with multiple params
      *
@@ -455,11 +457,11 @@ class Plugin_Actions_Tests extends PHPUnit_Framework_TestCase {
     public function test_do_action_1_params() {
         $hook = rand_str();
         yourls_add_action( $hook, array( $this, 'accept_multiple_params' ) );
-        
+
         $this->expectOutputString( "array (0 => 'hello',)" );
         yourls_do_action( $hook, 'hello' );
     }
-    
+
     /**
      * Test yourls_do_action() with multiple params
      *
@@ -470,11 +472,11 @@ class Plugin_Actions_Tests extends PHPUnit_Framework_TestCase {
     public function test_do_action_2_params() {
         $hook = rand_str();
         yourls_add_action( $hook, array( $this, 'accept_multiple_params' ) );
-        
+
         $this->expectOutputString( "array (0 => 'hello',1 => 'world',)" );
         yourls_do_action( $hook, 'hello', 'world' );
     }
-    
+
     /**
      * Dummy function -- just modifies the value of a global var
      */

--- a/tests/plugins/filters.php
+++ b/tests/plugins/filters.php
@@ -8,7 +8,7 @@
  */
 
 class Plugin_Filters_Tests extends PHPUnit_Framework_TestCase {
-    
+
     /**
      * this var will allow to share "$this" across multiple tests here
      */
@@ -27,16 +27,16 @@ class Plugin_Filters_Tests extends PHPUnit_Framework_TestCase {
         $this->assertFalse( yourls_has_filter( $hook ) );
         yourls_add_filter( $hook, rand_str() );
         $this->assertTrue( yourls_has_filter( $hook ) );
-        
+
         // Specific function name to test with yourls_apply_filter
         $hook = rand_str();
         $this->assertFalse( yourls_has_filter( $hook ) );
         yourls_add_filter( $hook, 'change_variable' );
         $this->assertTrue( yourls_has_filter( $hook ) );
-        
+
         return $hook;
 	}
-    
+
 	/**
 	 * Check applying a filter hooked with a simple function name
 	 *
@@ -45,12 +45,12 @@ class Plugin_Filters_Tests extends PHPUnit_Framework_TestCase {
 	 */
 	public function test_apply_filter_funcname( $hook ) {
         $var = rand_str();
-        
+
         $filtered = yourls_apply_filter( $hook, $var );
         $this->assertNotSame( $var, $filtered );
 	}
-    
-    
+
+
     /**
      * Check removing a filter hooked with a simple function name
      *
@@ -59,14 +59,14 @@ class Plugin_Filters_Tests extends PHPUnit_Framework_TestCase {
     public function test_remove_filter_funcname() {
         $hook = rand_str();
         $function = rand_str();
-        
+
         $this->assertFalse( yourls_has_filter( $hook ) );
         yourls_add_filter( $hook, $function );
         $this->assertTrue( yourls_has_filter( $hook ) );
-        
+
         $removed = yourls_remove_filter( $hook, $function );
         $this->assertTrue( $removed );
-        $this->assertFalse( yourls_has_filter( $hook ) );        
+        $this->assertFalse( yourls_has_filter( $hook ) );
     }
 
     /**
@@ -82,7 +82,7 @@ class Plugin_Filters_Tests extends PHPUnit_Framework_TestCase {
         yourls_add_filter( $hook, rand_str() );
         $this->assertArrayHasKey( 10, $yourls_filters[$hook] );
     }
-    
+
     /**
      * Check removing a filter with non default priority
      *
@@ -95,20 +95,20 @@ class Plugin_Filters_Tests extends PHPUnit_Framework_TestCase {
         do {
             $priority = rand( 1,100 );
         } while ( $priority == 10 );
-        
+
         $this->assertFalse( yourls_has_filter( $hook ) );
         yourls_add_filter( $hook, $function, $priority );
         $this->assertTrue( yourls_has_filter( $hook ) );
-        
+
         $removed = yourls_remove_filter( $hook, $function );
         $this->assertFalse( $removed );
-        
+
         $removed = yourls_remove_filter( $hook, $function, $priority );
         $this->assertTrue( $removed );
-        $this->assertFalse( yourls_has_filter( $hook ) );        
+        $this->assertFalse( yourls_has_filter( $hook ) );
     }
 
-    
+
 	/**
 	 * Check adding a filter with an anonymous function using create_function()
      *
@@ -119,12 +119,14 @@ class Plugin_Filters_Tests extends PHPUnit_Framework_TestCase {
 	public function test_add_filter_create_function() {
         $hook = rand_str();
         $this->assertFalse( yourls_has_filter( $hook ) );
-        yourls_add_filter( $hook, create_function( '', 'return rand_str();' ) );
+        yourls_add_filter( $hook, function() {
+            return rand_str();
+        });
         $this->assertTrue( yourls_has_filter( $hook ) );
-               
+
         return $hook;
 	}
-    
+
 	/**
 	 * Check applying a filter hooked with an anonymous function using create_function()
 	 *
@@ -133,12 +135,12 @@ class Plugin_Filters_Tests extends PHPUnit_Framework_TestCase {
 	 */
 	public function test_apply_filter_create_function( $hook ) {
         $var = rand_str();
-        
+
         $filtered = yourls_apply_filter( $hook, $var );
         $this->assertNotSame( $var, $filtered );
 	}
-    
-    
+
+
 	/**
 	 * Check adding a filter with function within class
      *
@@ -151,10 +153,10 @@ class Plugin_Filters_Tests extends PHPUnit_Framework_TestCase {
         $this->assertFalse( yourls_has_filter( $hook ) );
         yourls_add_filter( $hook, 'Change_Variable::change_it' );
         $this->assertTrue( yourls_has_filter( $hook ) );
-               
+
         return $hook;
 	}
-    
+
 	/**
 	 * Check applying a filter hooked with function within class
 	 *
@@ -163,11 +165,11 @@ class Plugin_Filters_Tests extends PHPUnit_Framework_TestCase {
 	 */
 	public function test_apply_filter_within_class( $hook ) {
         $var = rand_str();
-        
+
         $filtered = yourls_apply_filter( $hook, $var );
         $this->assertNotSame( $var, $filtered );
 	}
-    
+
     /**
      * Check removing a filter hooked with function within class
      *
@@ -177,9 +179,9 @@ class Plugin_Filters_Tests extends PHPUnit_Framework_TestCase {
     public function test_remove_filter_within_class( $hook ) {
         $removed = yourls_remove_filter( $hook, 'Change_Variable::change_it' );
         $this->assertTrue( $removed );
-        $this->assertFalse( yourls_has_filter( $hook ) );        
+        $this->assertFalse( yourls_has_filter( $hook ) );
     }
-    
+
 
 	/**
 	 * Check adding filter with function within class using an array
@@ -193,10 +195,10 @@ class Plugin_Filters_Tests extends PHPUnit_Framework_TestCase {
         $this->assertFalse( yourls_has_filter( $hook ) );
         yourls_add_filter( $hook, array( 'Change_Variable', 'change_it' ) );
         $this->assertTrue( yourls_has_filter( $hook ) );
-               
+
         return $hook;
 	}
-    
+
 	/**
 	 * Check applying a filter hooked with function within class
 	 *
@@ -208,7 +210,7 @@ class Plugin_Filters_Tests extends PHPUnit_Framework_TestCase {
         $filtered = yourls_apply_filter( $hook, $var );
         $this->assertNotSame( $var, $filtered );
 	}
-    
+
     /**
      * Check removing a filter hooked with function within class using an array
      *
@@ -218,10 +220,10 @@ class Plugin_Filters_Tests extends PHPUnit_Framework_TestCase {
     public function test_remove_filter_within_class_array( $hook ) {
         $removed = yourls_remove_filter( $hook, array( 'Change_Variable', 'change_it' ) );
         $this->assertTrue( $removed );
-        $this->assertFalse( yourls_has_filter( $hook ) );        
+        $this->assertFalse( yourls_has_filter( $hook ) );
     }
 
-    
+
 	/**
 	 * Check adding a filter with function within class instance
      *
@@ -232,7 +234,7 @@ class Plugin_Filters_Tests extends PHPUnit_Framework_TestCase {
 	public function test_add_filter_within_class_instance() {
         /* Note : in the unit tests context, we cannot rely on "$this" keeping the same
          * between tests, whereas it totally works in a "normal" class context
-         * For this reason, using yourls_add_filter($hook, array($this, 'some_func')) in one test and 
+         * For this reason, using yourls_add_filter($hook, array($this, 'some_func')) in one test and
          * yourls_remove_filter($hook,array($this,'some_func')) in another test doesn't work.
          * To circumvent this, we're storing $this in $instance.
          */
@@ -244,7 +246,7 @@ class Plugin_Filters_Tests extends PHPUnit_Framework_TestCase {
 
         return $hook;
 	}
-    
+
 	/**
 	 * Check applying a filter hooked with function within class instance
 	 *
@@ -256,7 +258,7 @@ class Plugin_Filters_Tests extends PHPUnit_Framework_TestCase {
         $filtered = yourls_apply_filter( $hook, $var );
         $this->assertNotSame( $var, $filtered );
 	}
-    
+
     /**
      * Check removing a filter hooked with function within class
      *
@@ -277,14 +279,14 @@ class Plugin_Filters_Tests extends PHPUnit_Framework_TestCase {
 	 */
 	public function test_add_filter_class_and_array() {
         $hook = rand_str();
-        
+
         $this->assertFalse( yourls_has_filter( $hook ) );
-        
+
         yourls_add_filter( $hook, array( 'Class', 'Method' ) );
         $this->assertSame( 10, yourls_has_filter( $hook, array( 'Class', 'Method' ) ) );
         $this->assertSame( 10, yourls_has_filter( $hook, 'Class::Method' ) );
 	}
-    
+
 
 	/**
 	 * Check adding a filter with anonymous function using closure
@@ -298,10 +300,10 @@ class Plugin_Filters_Tests extends PHPUnit_Framework_TestCase {
         $this->assertFalse( yourls_has_filter( $hook ) );
         yourls_add_filter( $hook, function() { return rand_str(); } );
         $this->assertTrue( yourls_has_filter( $hook ) );
-               
+
         return $hook;
 	}
-       
+
 	/**
 	 * Check applying a filter hooked with anonymous function using closure
 	 *
@@ -310,7 +312,7 @@ class Plugin_Filters_Tests extends PHPUnit_Framework_TestCase {
 	 */
 	public function test_apply_filter_closure( $hook ) {
         $var = rand_str();
-        
+
         $filtered = yourls_apply_filter( $hook, $var );
         $this->assertNotSame( $var, $filtered );
 	}
@@ -323,10 +325,10 @@ class Plugin_Filters_Tests extends PHPUnit_Framework_TestCase {
 	public function test_multiple_filter() {
         $hook = rand_str();
         $var  = rand_str();
-        
+
         yourls_add_filter( $hook, function( $in ) { return $in . "1"; } );
         yourls_add_filter( $hook, function( $in ) { return $in . "2"; } );
-        
+
         $filtered = yourls_apply_filter( $hook, $var );
         $this->assertSame( $var . "1" . "2", $filtered );
 	}
@@ -339,19 +341,19 @@ class Plugin_Filters_Tests extends PHPUnit_Framework_TestCase {
     public function test_multiple_filter_with_priority() {
         $hook = rand_str();
         $var  = rand_str();
-        
+
         yourls_add_filter( $hook, function( $in ) { return $in . "1"; }, 10 );
         yourls_add_filter( $hook, function( $in ) { return $in . "2"; }, 9 );
-        
+
         $filtered = yourls_apply_filter( $hook, $var );
         $this->assertSame( $var . "2" . "1", $filtered );
-        
+
         $hook = rand_str();
         $var  = rand_str();
 
         yourls_add_filter( $hook, function( $in ) { return $in . "1"; }, 10 );
         yourls_add_filter( $hook, function( $in ) { return $in . "2"; }, 11 );
-        
+
         $filtered = yourls_apply_filter( $hook, $var );
         $this->assertSame( $var . "1" . "2", $filtered );
     }
@@ -363,10 +365,10 @@ class Plugin_Filters_Tests extends PHPUnit_Framework_TestCase {
      */
     public function test_has_filter_return_values() {
         $hook = rand_str();
-        
+
         yourls_add_filter( $hook, 'some_function' );
         yourls_add_filter( $hook, 'some_other_function', 1337 );
-        
+
         $this->assertTrue( yourls_has_filter( $hook ) );
         $this->assertSame( 10, yourls_has_filter( $hook, 'some_function' ) );
         $this->assertSame( 1337, yourls_has_filter( $hook, 'some_other_function' ) );
@@ -403,14 +405,14 @@ class Plugin_Filters_Tests extends PHPUnit_Framework_TestCase {
         yourls_add_filter( $hook, function( $var1 = '', $var2 = '' ) { return "$var1 $var2"; }, 10, 1 );
         $test = yourls_apply_filter( $hook, 'hello', 'world' );
         $this->assertSame( $test, 'hello ' );
-        
+
         // Ask for 2 arguments and provide 1
         $hook = rand_str();
         yourls_add_filter( $hook, function( $var1 = '', $var2 = '' ) { return "$var1 $var2"; }, 10, 2 );
         $test = yourls_apply_filter( $hook, 'hello' );
         $this->assertSame( $test, 'hello ' );
     }
-    
+
 	/**
 	 * Make sure yourls_apply_filter accepts an arbitrary number of elements if unspecified
 	 *
@@ -421,19 +423,19 @@ class Plugin_Filters_Tests extends PHPUnit_Framework_TestCase {
         $var1 = rand_str();
         $var2 = rand_str();
         $var3 = rand_str();
-        
+
         yourls_add_filter( $hook, function( $var1 = '', $var2 = '', $var3 = '' ) { return $var1 . $var2 . $var3; } );
-        
+
         $filtered = yourls_apply_filter( $hook, $var1 );
         $this->assertSame( $var1, $filtered );
-    
+
         $filtered = yourls_apply_filter( $hook, $var1, $var2 );
         $this->assertSame( $var1 . $var2, $filtered );
-    
+
         $filtered = yourls_apply_filter( $hook, $var1, $var2, $var3 );
         $this->assertSame( $var1 . $var2 . $var3, $filtered );
     }
-   
+
     /**
      * Check applying multiple filters and count executions
      *
@@ -441,13 +443,13 @@ class Plugin_Filters_Tests extends PHPUnit_Framework_TestCase {
      */
     public function test_multiple_filter_and_count() {
         $hook = rand_str();
-        
+
         $times = mt_rand( 5, 15 );
         for ( $i = 1; $i <= $times; $i++ ) {
             // This will register every time a different closure function
             yourls_add_filter( $hook, function() { global $counter; ++$counter; return rand_str(); } );
         }
-        
+
         global $counter;
         $counter = 0;
         $filtered = yourls_apply_filter( $hook, rand_str() );


### PR DESCRIPTION
# Changed log
- Fix Travis CI build.
- Let the `php-7.2` remove from `allow_failures` setting because this version is stable and should be successful.
- Add `php-7.3` test because this version is stable.
- In the dist `Xenial`, it should add the `services` setting to setup the `MySQL` service.
- Since this[ Travis CI blog post is published](https://blog.travis-ci.com/2019-04-15-xenial-default-build-environment), the default dist is `Xenial`.
To support `php-5.4` and `php-5.5` version tests completely, it should setup the `trusty` dist for these versions.